### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,8 +26,7 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item.update(items_params)
-    if @item.save
+  if @item.update(items_params)
     redirect_to item_path
     else
       render "edit"

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new]
+  before_action :authenticate_user!, only: [:new, :update, :edit]
   before_action :set_item, only: [:edit, :update, :show]
   def index
     @items = Item.all.order('id DESC')
@@ -20,11 +20,12 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
+    unless @item.user_id == current_user.id
+      redirect_to items_path
+    end
   end
 
   def update
-    @item = Item.find(params[:id])
     @item.update(items_params)
     if @item.save
     redirect_to item_path
@@ -34,7 +35,6 @@ class ItemsController < ApplicationController
 end
 
   def show
-    @item = Item.find(params[:id])
   end
 
 private 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,18 @@ class ItemsController < ApplicationController
     end
   end
 
+ 
+
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    @item.update(items_params)
+    redirect_to item_path
+  end
+
   def show
     @item = Item.find(params[:id])
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
+  before_action :set_item, only: [:edit, :update, :show]
   def index
     @items = Item.all.order('id DESC')
   end
@@ -18,8 +19,6 @@ class ItemsController < ApplicationController
     end
   end
 
- 
-
   def edit
     @item = Item.find(params[:id])
   end
@@ -27,8 +26,12 @@ class ItemsController < ApplicationController
   def update
     @item = Item.find(params[:id])
     @item.update(items_params)
+    if @item.save
     redirect_to item_path
+    else
+      render "edit"
   end
+end
 
   def show
     @item = Item.find(params[:id])
@@ -38,5 +41,8 @@ private
 def items_params
   params.require(:item).permit(:image, :name,:text,:category_id,:item_status_id,:item_fee_status_id,:item_prefecture_id,:item_scheduled_delivery_id,:price).merge(user_id: current_user.id)
 end
-end
 
+def set_item
+  @item = Item.find(params[:id])
+end
+end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,10 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model:@item , local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :text , class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:item_status_id, ItemStatus.all , :id, :name, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:item_fee_status_id, ItemFeeStatus.all, :id, :name, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:item_prefecture_id, ItemPrefecture.all , :id, :name, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:item_scheduled_delivery_id, ItemScheduledDelivery.all , :id, :name, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +141,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,9 +9,8 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model:@item , local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+  
 
     <%# 出品画像 %>
     <div class="img-upload">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -5,7 +5,7 @@
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model:@item , url:"/items" ,  local: true do |f| %>
+    <%= form_with model:@item , local: true do |f| %>
    
     <%= render 'shared/error_messages', model: f.object %>
 


### PR DESCRIPTION
最終課題、商品情報編集機能の実装になります。
①商品情報（商品画像・商品名・商品の状態など）を変更できること
https://gyazo.com/a1cdb34805ccc2ae53c4f007ea7b280b（変更前）
編集をクリックし情報を変更
https://gyazo.com/67714e0f25f9680b20e89a2f20e9dcfa

②何も編集せずに更新をしても画像無しの商品にならない
https://gyazo.com/576ffc17ad3d672ab036772871f768f7

③出品者だけが編集ページに遷移できること
出品者の場合
https://gyazo.com/960fb8cae16e36883f66822b33ee5901
出品者ではない場合
https://gyazo.com/d5bd2a8ca512d70acfcde3795b3b4840

④商品出品時とほぼ同じUIで編集機能が実装できること
商品出品時
https://gyazo.com/976d7eed828c2e9dc41fd4ca56eb977a
編集時
https://gyazo.com/8d24bc829dee8eb73e305a74d4625ebb

⑤商品名やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で表示されること（画像に関しては、表示されない状態で良い）
https://gyazo.com/d63a36a486507cfcba84600e10a2e16a